### PR TITLE
[OSSAPI-566] Add /ip endpoint integrations

### DIFF
--- a/examples/service/docker-compose.yml
+++ b/examples/service/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       DEPLOY_ENV: "int"
     depends_on:
       - gosrvlibexample
+      - gosrvlibexample_smocker_ipify
     volumes:
       - ./target/binutil/dockerize:/usr/bin/dockerize
 
@@ -19,6 +20,14 @@ services:
     restart: always
     env_file:
       - target/gosrvlibexample.integration.env
-    entrypoint: ["/usr/bin/dockerize", "/usr/bin/gosrvlibexample"]
+    entrypoint: [
+        "/usr/bin/dockerize",
+        "-wait", "tcp://gosrvlibexample_smocker_ipify:8081",
+        "/usr/bin/gosrvlibexample"
+    ]
     volumes:
       - ./target/binutil/dockerize:/usr/bin/dockerize
+
+  gosrvlibexample_smocker_ipify:
+    container_name: gosrvlibexample_smocker_ipify
+    image: thiht/smocker

--- a/examples/service/openapi_monitoring.yaml
+++ b/examples/service/openapi_monitoring.yaml
@@ -112,6 +112,36 @@ paths:
       responses:
         '200':
           description: pprof profiling data
+  /ip:
+    get:
+      tags:
+        - status
+      summary: Returns the public IP address of this service instance
+      responses:
+        '200':
+          description: IP address of this service instance
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/response'
+                  - type: object
+                    properties:
+                      data:
+                        type: string
+                        description: Public IP address
+        '424':
+          description: Unable to connect to the ipify service
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/response'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        description: content
 components:
   schemas:
     response:

--- a/examples/service/resources/test/integration/entrypoint.sh
+++ b/examples/service/resources/test/integration/entrypoint.sh
@@ -6,7 +6,14 @@ set -e
 dockerize \
     -timeout 30s \
     -wait tcp://gosrvlibexample:8082 \
+    -wait http://gosrvlibexample_smocker_ipify:8081/version \
     echo
+
+# configure smocker mocks for the ipify client
+curl -s -XPOST \
+  --header "Content-Type: application/x-yaml" \
+  --data-binary "@resources/test/integration/smocker/ipify_apitest.yaml" \
+  http://gosrvlibexample_smocker_ipify:8081/mocks
 
 # run tests
 make openapitest apitest DEPLOY_ENV=int

--- a/examples/service/resources/test/integration/smocker/ipify_apitest.yaml
+++ b/examples/service/resources/test/integration/smocker/ipify_apitest.yaml
@@ -1,0 +1,10 @@
+# Default response
+- request:
+    method: GET
+    path: /ip
+  response:
+    status: 200
+    headers:
+      Content-Type: text/plain
+    body: >
+      0.0.0.0

--- a/examples/service/resources/test/venom/monitoring/api.yaml
+++ b/examples/service/resources/test/venom/monitoring/api.yaml
@@ -87,3 +87,12 @@ testcases:
     url: '{{.gosrvlibexample.url}}/pprof'
     assertions:
     - result.statuscode ShouldEqual 200
+
+- name: ip
+  steps:
+  - type: http
+    ignore_verify_ssl optional: true
+    method: GET
+    url: '{{.gosrvlibexample.url}}/ip'
+    assertions:
+    - result.statuscode ShouldEqual 200


### PR DESCRIPTION
Note: the ipify Smocker container is not actually used, it will require a redirection or an injection of the Smocker URL into the code. However it is a good example on how to use Smocker.