### PR TITLE
Reuse http.Client connections

### DIFF
--- a/pkg/healthcheck/checks.go
+++ b/pkg/healthcheck/checks.go
@@ -8,16 +8,11 @@ import (
 )
 
 // CheckHTTPStatus checks if the given HTTP request responds with the expected status code
-func CheckHTTPStatus(ctx context.Context, method string, url string, wantStatusCode int, timeout time.Duration) error {
-	httpClient := http.Client{
-		Timeout: timeout,
-	}
-
+func CheckHTTPStatus(ctx context.Context, httpClient *http.Client, method string, url string, wantStatusCode int, timeout time.Duration) error {
 	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %v", err)
 	}
-
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("healthcheck request: %v", err)

--- a/pkg/healthcheck/checks.go
+++ b/pkg/healthcheck/checks.go
@@ -7,8 +7,13 @@ import (
 	"time"
 )
 
+// HTTPClient contains the function to perform the actual HTTP request
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
 // CheckHTTPStatus checks if the given HTTP request responds with the expected status code
-func CheckHTTPStatus(ctx context.Context, httpClient *http.Client, method string, url string, wantStatusCode int, timeout time.Duration) error {
+func CheckHTTPStatus(ctx context.Context, httpClient HTTPClient, method string, url string, wantStatusCode int, timeout time.Duration) error {
 	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %v", err)

--- a/pkg/healthcheck/checks_test.go
+++ b/pkg/healthcheck/checks_test.go
@@ -80,6 +80,7 @@ func TestCheckHttpStatus(t *testing.T) {
 			wantErr:           false,
 		},
 	}
+	httpClient := &http.Client{Timeout: 1 * time.Second}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -102,7 +103,7 @@ func TestCheckHttpStatus(t *testing.T) {
 			ts := httptest.NewServer(mux)
 			defer ts.Close()
 
-			err := CheckHTTPStatus(tt.checkContext, tt.checkMethod, ts.URL, tt.checkWantStatus, tt.checkTimeout)
+			err := CheckHTTPStatus(tt.checkContext, httpClient, tt.checkMethod, ts.URL, tt.checkWantStatus, tt.checkTimeout)
 			t.Logf("check error: %v", err)
 			if tt.wantErr {
 				require.Error(t, err, "CheckHTTPStatus() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/healthcheck/checks_test.go
+++ b/pkg/healthcheck/checks_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testHTTPClient = &http.Client{Timeout: 2 * time.Second}
+
 // nolint:gocognit
 func TestCheckHttpStatus(t *testing.T) {
 	tests := []struct {
@@ -80,7 +82,6 @@ func TestCheckHttpStatus(t *testing.T) {
 			wantErr:           false,
 		},
 	}
-	httpClient := &http.Client{Timeout: 1 * time.Second}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -103,7 +104,7 @@ func TestCheckHttpStatus(t *testing.T) {
 			ts := httptest.NewServer(mux)
 			defer ts.Close()
 
-			err := CheckHTTPStatus(tt.checkContext, httpClient, tt.checkMethod, ts.URL, tt.checkWantStatus, tt.checkTimeout)
+			err := CheckHTTPStatus(tt.checkContext, testHTTPClient, tt.checkMethod, ts.URL, tt.checkWantStatus, tt.checkTimeout)
 			t.Logf("check error: %v", err)
 			if tt.wantErr {
 				require.Error(t, err, "CheckHTTPStatus() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/profiling/profiling_test.go
+++ b/pkg/profiling/profiling_test.go
@@ -43,6 +43,7 @@ func TestPProfHandler(t *testing.T) {
 			path: "/pprof/heap",
 		},
 	}
+	httpClient := &http.Client{Timeout: 2 * time.Second}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -56,8 +57,7 @@ func TestPProfHandler(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", ts.URL, tt.path), nil)
 			require.NoError(t, err, "unexpected error while creating request for path %q", tt.path)
 
-			c := &http.Client{Timeout: 2 * time.Second}
-			resp, err := c.Do(req)
+			resp, err := httpClient.Do(req)
 			require.NoError(t, err, "unexpected error while performing request %q", req.URL.String())
 			require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d", resp.StatusCode)
 		})

--- a/pkg/profiling/profiling_test.go
+++ b/pkg/profiling/profiling_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testHTTPClient = &http.Client{Timeout: 2 * time.Second}
+
 func TestPProfHandler(t *testing.T) {
 	tests := []struct {
 		name string
@@ -43,7 +45,6 @@ func TestPProfHandler(t *testing.T) {
 			path: "/pprof/heap",
 		},
 	}
-	httpClient := &http.Client{Timeout: 2 * time.Second}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,7 +58,7 @@ func TestPProfHandler(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", ts.URL, tt.path), nil)
 			require.NoError(t, err, "unexpected error while creating request for path %q", tt.path)
 
-			resp, err := httpClient.Do(req)
+			resp, err := testHTTPClient.Do(req)
 			require.NoError(t, err, "unexpected error while performing request %q", req.URL.String())
 			require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code %d", resp.StatusCode)
 		})


### PR DESCRIPTION
In this PR we ensure the reuse of http.Client connections.

Breaking change:
The CheckHTTPStatus function signature has changed to allow injecting the http.Client. This is typically already defined in the client using this function.