### PR TITLE
Return the set value instead of a boolean

### DIFF
--- a/pkg/traceid/traceid.go
+++ b/pkg/traceid/traceid.go
@@ -38,15 +38,15 @@ func FromContext(ctx context.Context, def string) string {
 
 // ToHTTPRequest set the trace ID HTTP Request Header with the value retrieved from the context.
 // If the traceid is not found in the context, then the default value is set.
-// Returns true when the default value is used.
-func ToHTTPRequest(ctx context.Context, r *http.Request, key, def string) bool {
+// Returns the set ID.
+func ToHTTPRequest(ctx context.Context, r *http.Request, key, def string) string {
 	id := FromContext(ctx, def)
 	r.Header.Set(key, id)
-	return id == def
+	return id
 }
 
 // FromHTTPRequest retrieves the trace ID from an HTTP Request.
-// If not found the defaultValue is returned instead.
+// If not found the default value is returned instead.
 func FromHTTPRequest(r *http.Request, key, def string) string {
 	return httputil.HeaderOrDefault(r, key, def)
 }

--- a/pkg/traceid/traceid_test.go
+++ b/pkg/traceid/traceid_test.go
@@ -45,8 +45,8 @@ func TestToHTTPRequest(t *testing.T) {
 	r1, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)
 
-	usedDefault1 := ToHTTPRequest(context.Background(), r1, DefaultKey, DefaultValue)
-	require.Equal(t, usedDefault1, true)
+	id1 := ToHTTPRequest(context.Background(), r1, DefaultKey, DefaultValue)
+	require.Equal(t, id1, DefaultValue)
 	require.Equal(t, r1.Header.Get(DefaultKey), DefaultValue)
 
 	// header set
@@ -55,8 +55,8 @@ func TestToHTTPRequest(t *testing.T) {
 	ctx := ToContext(context.Background(), "test-904117")
 	r2 = r2.WithContext(ctx)
 
-	usedDefault2 := ToHTTPRequest(ctx, r2, DefaultKey, DefaultValue)
-	require.Equal(t, usedDefault2, false)
+	id2 := ToHTTPRequest(ctx, r2, DefaultKey, DefaultValue)
+	require.NotEqual(t, id2, DefaultValue)
 	require.Equal(t, "test-904117", r2.Header.Get(DefaultKey))
 }
 


### PR DESCRIPTION
Returning the set ID is more generic and more flexible.
The comparison can be done in the calling code.