### PR TITLE
Apply HTTP middleware chain

### DIFF
--- a/pkg/httpserver/config_test.go
+++ b/pkg/httpserver/config_test.go
@@ -11,7 +11,7 @@ import (
 func Test_defaultConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := defaultConfig()
+	cfg := defaultConfig(testutil.Context())
 
 	require.NotNil(t, cfg)
 	require.NotNil(t, cfg.metricsHandlerFunc)
@@ -115,7 +115,7 @@ func Test_config_validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := defaultConfig()
+			cfg := defaultConfig(testutil.Context())
 			if tt.setupConfig != nil {
 				tt.setupConfig(cfg)
 			}

--- a/pkg/httpserver/middleware_test.go
+++ b/pkg/httpserver/middleware_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestApplyMiddleware(t *testing.T) {
+	t.Parallel()
+
 	// Custom middleware chain with logger.
 	ctx, logs := testutil.ContextWithLogObserver(zapcore.DebugLevel)
 

--- a/pkg/httpserver/options.go
+++ b/pkg/httpserver/options.go
@@ -162,3 +162,11 @@ func WithRedactFn(fn RedactFn) Option {
 		return nil
 	}
 }
+
+// WithMiddlewareChain overrides the default chain of middlewares.
+func WithMiddlewareChain(m []Middleware) Option {
+	return func(cfg *config) error {
+		cfg.middleware = m
+		return nil
+	}
+}

--- a/pkg/httpserver/options_test.go
+++ b/pkg/httpserver/options_test.go
@@ -260,3 +260,16 @@ func TestWithRedactFn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "alphatest", cfg.redactFn("alpha"))
 }
+
+func TestWithMiddlewareChain(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config{}
+	f := func(http.Handler) http.Handler {
+		return http.DefaultServeMux
+	}
+	m := []Middleware{f}
+	err := WithMiddlewareChain(m)(cfg)
+	require.NoError(t, err)
+	require.Equal(t, m, cfg.middleware)
+}


### PR DESCRIPTION
The PR is making it more convenient for the applications to:
- add custom logging fields to the `zap.Logger` instance (simple usecase)
- apply instrumentation, authorization, even caching and so on through middleware chaining, before/after the default logging middleware. (more complex scenarios)

This is achieved by introducing the option for the application to provide a custom middleware chain to be applied to the `http.Handler`. So the versatility of the lib gets improved, making it even more attractive to a wider array of usecases, while preserving the 100% unit test coverage. 